### PR TITLE
Returned all candidates votes instead of only the winners for national

### DIFF
--- a/src/ElectionResults.API/Controllers/BallotsController.cs
+++ b/src/ElectionResults.API/Controllers/BallotsController.cs
@@ -42,7 +42,6 @@ namespace ElectionResults.API.Controllers
         }
 
         [HttpGet("ballot")]
-        //[ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
         public async Task<ActionResult<ElectionResponse>> GetBallot([FromQuery] ElectionResultsQuery query)
         {
             try

--- a/src/ElectionResults.Core/Elections/IResultsAggregator.cs
+++ b/src/ElectionResults.Core/Elections/IResultsAggregator.cs
@@ -29,8 +29,6 @@ namespace ElectionResults.Core.Elections
         List<CandidateResult> RetrieveWinners(List<CandidateResult> results,
             BallotType ballotType);
 
-        Task<Result<List<CandidateResult>>> GetAllLocalityWinners(int ballotId);
         Task<Result<List<CandidateResult>>> GetWinningCandidatesByCounty(int ballotId);
-
     }
 }

--- a/src/ElectionResults.Core/Elections/ResultsAggregator.cs
+++ b/src/ElectionResults.Core/Elections/ResultsAggregator.cs
@@ -278,7 +278,7 @@ namespace ElectionResults.Core.Elections
             {
                 if (!ballot.AllowsDivision(query.Division, query.LocalityId.GetValueOrDefault()) && !ballot.Election.Live)
                 {
-                    var aggregatedVotes = await RetrieveAggregatedVotes(query, ballot);
+                    var aggregatedVotes = await RetrieveAggregatedVotes(dbContext, query, ballot);
                     liveElectionInfo.Candidates = aggregatedVotes;
                     return liveElectionInfo;
                 }
@@ -313,7 +313,8 @@ namespace ElectionResults.Core.Elections
             return results;
         }
 
-        private async Task<List<CandidateResult>> RetrieveAggregatedVotes(ElectionResultsQuery query, Ballot ballot)
+        private async Task<List<CandidateResult>> RetrieveAggregatedVotes(ApplicationDbContext dbContext,
+            ElectionResultsQuery query, Ballot ballot)
         {
             switch (query.Division)
             {
@@ -336,15 +337,16 @@ namespace ElectionResults.Core.Elections
                             ballot.BallotType == BallotType.CountyCouncilPresident)
                         {
                             result = await _winnersAggregator.GetWinningCandidatesByCounty(ballot.BallotId);
+                            if (result.IsSuccess)
+                                return _winnersAggregator.RetrieveWinners(result.Value, ballot.BallotType);
                         }
                         else
                         {
-                            result = await _winnersAggregator.GetAllLocalityWinners(ballot.BallotId);
-                        }
-                        if (result.IsSuccess)
-                        {
-                            var candidateResults = _winnersAggregator.RetrieveWinners(result.Value, ballot.BallotType);
-                            return candidateResults;
+                            var resultsForElection = await dbContext.CandidateResults
+                                .Include(c => c.Party)
+                                .Where(c => c.BallotId == query.BallotId && c.Division == ElectionDivision.Locality)
+                                .ToListAsync();
+                            return _winnersAggregator.RetrieveWinners(resultsForElection, ballot.BallotType);
                         }
                         throw new Exception(result.Error);
                     }

--- a/src/ElectionResults.Core/Elections/WinnersAggregator.cs
+++ b/src/ElectionResults.Core/Elections/WinnersAggregator.cs
@@ -340,45 +340,5 @@ namespace ElectionResults.Core.Elections
 
             return candidateResults;
         }
-
-        public async Task<Result<List<CandidateResult>>> GetAllLocalityWinners(int ballotId)
-        {
-            var dbWinners = await GetWinners(ballotId, null, ElectionDivision.Locality);
-            if (dbWinners.Count > 0)
-                return dbWinners.Select(w => w.Candidate).ToList();
-            _appCache.Remove(MemoryCache.CreateWinnersKey(ballotId, null, ElectionDivision.Locality));
-            var winners = new List<CandidateResult>();
-            var allLocalities = await _dbContext.Localities.ToListAsync();
-            var resultsForElection = await _dbContext.CandidateResults
-                .Include(c => c.Party)
-                .Where(c => c.BallotId == ballotId && c.Division == ElectionDivision.Locality)
-                .ToListAsync();
-
-            var localitiesForThisElection = allLocalities
-                .Where(l => resultsForElection.Any(r => r.LocalityId == l.LocalityId)).ToList();
-            var turnouts = await _dbContext.Turnouts
-                .Where(c => c.BallotId == ballotId &&
-                            c.Division == ElectionDivision.Locality)
-                .ToListAsync();
-            List<Winner> winningCandidates = new List<Winner>();
-            foreach (var locality in localitiesForThisElection)
-            {
-                var localityWinner = resultsForElection
-                    .Where(c => c.LocalityId == locality.LocalityId)
-                    .OrderByDescending(c => c.Votes)
-                    .FirstOrDefault();
-                if (localityWinner == null)
-                    continue;
-                var turnoutForLocality = turnouts
-                    .FirstOrDefault(c => c.LocalityId == locality.LocalityId);
-                winners.Add(localityWinner);
-                winningCandidates.Add(CreateWinner(ballotId, null, localityWinner, turnoutForLocality, ElectionDivision.Locality));
-            }
-
-            await SaveWinners(winningCandidates);
-
-            return Result.Success(winners);
-        }
-
     }
 }

--- a/src/ElectionResults.Core/Scheduler/CsvDownloaderJob.cs
+++ b/src/ElectionResults.Core/Scheduler/CsvDownloaderJob.cs
@@ -45,7 +45,7 @@ namespace ElectionResults.Core.Scheduler
 
         public async Task DownloadFiles()
         {
-            await DownloadCandidates();
+           // await DownloadCandidates();
         }
 
         private async Task DownloadCandidates()


### PR DESCRIPTION
### What does it fix?
The list of winners from the national scope is replaced with a list of candidates ordered by their number of votes. Thus, the total will match the number of votes for that turnout.



### How has it been tested?
Local