### PR TITLE
Added settings for download interval and caching

### DIFF
--- a/src/ElectionResults.API/appsettings.Development.json
+++ b/src/ElectionResults.API/appsettings.Development.json
@@ -15,6 +15,8 @@
     "FtpUser": "",
     "FtpPassword": "",
     "TurnoutUrl": "https://prezenta.roaep.ro/presa/prezenta/PRL/presence_now.csv",
-    "ResultsUrl": "https://code4storage.blob.core.windows.net/results/"
+    "ResultsUrl": "https://code4storage.blob.core.windows.net/results/",
+    "TurnoutIntervalInMinutes": 30,
+    "ResultsCacheInMinutes": 0
   }
 }

--- a/src/ElectionResults.API/appsettings.json
+++ b/src/ElectionResults.API/appsettings.json
@@ -21,6 +21,8 @@
     "FtpUser": "",
     "FtpPassword": "",
     "TurnoutUrl": "https://prezenta.roaep.ro/presa/prezenta/PRL/presence_now.csv",
-    "ResultsUrl": "https://prezenta.roaep.ro/presa/pv/PRL/"
+    "ResultsUrl": "https://prezenta.roaep.ro/presa/pv/PRL/",
+    "TurnoutIntervalInMinutes": 5,
+    "ResultsCacheInMinutes": 5
   }
 }

--- a/src/ElectionResults.Core/Configuration/LiveElectionSettings.cs
+++ b/src/ElectionResults.Core/Configuration/LiveElectionSettings.cs
@@ -11,5 +11,9 @@ namespace ElectionResults.Core.Configuration
         public string TurnoutUrl { get; set; }
         
         public string ResultsUrl { get; set; }
+
+        public int TurnoutIntervalInMinutes { get; set; }
+
+        public int ResultsCacheInMinutes { get; set; }
     }
 }

--- a/src/ElectionResults.Core/Scheduler/ScheduledProcessor.cs
+++ b/src/ElectionResults.Core/Scheduler/ScheduledProcessor.cs
@@ -2,19 +2,22 @@
 using System.Threading;
 using System.Threading.Tasks;
 using ElectionResults.Core.BackgroundService;
+using ElectionResults.Core.Configuration;
 using ElectionResults.Core.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace ElectionResults.Core.Scheduler
 {
     public abstract class ScheduledProcessor : ScopedProcessor
     {
         private DateTime _nextRun;
-        private int _intervalInSeconds = 3600;
+        private LiveElectionSettings _settings;
 
-        public ScheduledProcessor(IServiceScopeFactory serviceScopeFactory) : base(serviceScopeFactory)
+        public ScheduledProcessor(IServiceScopeFactory serviceScopeFactory, IOptions<LiveElectionSettings> options) : base(serviceScopeFactory)
         {
             _nextRun = DateTime.Now.AddSeconds(1);
+            _settings = options.Value;
             Log.LogInformation($"Next run will be at {_nextRun:F}");
         }
 
@@ -28,7 +31,7 @@ namespace ElectionResults.Core.Scheduler
                     if (now > _nextRun)
                     {
                         await Process();
-                        _nextRun = DateTime.Now.AddSeconds(_intervalInSeconds);
+                        _nextRun = DateTime.Now.AddMinutes(_settings.TurnoutIntervalInMinutes);
                         Log.LogInformation($"Next run will be at {_nextRun:F}");
                     }
                 } while (!stoppingToken.IsCancellationRequested);

--- a/src/ElectionResults.Core/Scheduler/ScheduledTask.cs
+++ b/src/ElectionResults.Core/Scheduler/ScheduledTask.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
+using ElectionResults.Core.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace ElectionResults.Core.Scheduler
 {
@@ -9,8 +11,9 @@ namespace ElectionResults.Core.Scheduler
         private readonly ITurnoutCrawler _turnoutCrawler;
 
         public ScheduledTask(IServiceScopeFactory serviceScopeFactory,
-            ITurnoutCrawler turnoutCrawler)
-            : base(serviceScopeFactory)
+            ITurnoutCrawler turnoutCrawler,
+            IOptions<LiveElectionSettings> options)
+            : base(serviceScopeFactory, options)
         {
             _turnoutCrawler = turnoutCrawler;
         }


### PR DESCRIPTION
### What does it fix?
Added settings for download interval and caching

2 new settings have been added in appsettings.json:
`TurnoutIntervalInMinutes` and `ResultsCacheInMinutes`
The first one determines how often the turnout should be updated, and the second one determines the cache in minutes for ballot results. Both settings have a default of 5 minutes.


### How has it been tested?
Local
